### PR TITLE
Add an unbuilt flow client to preserve logger's flowtypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ And in terminal:
 const log = require('@sprucelabs/log')
 ```
 
+## Babel installation with flow support
+
+```javascript
+import log from '@sprucelabs/log/flow-client'
+```
+
+- Assumes you have a `@babel/preset-flow` properly configured.
+
 ## NodeJS (server) Installation
 
 ```js

--- a/flow-client.js
+++ b/flow-client.js
@@ -1,0 +1,5 @@
+// @flow
+
+const Log = require('./src/Log')
+
+module.exports = new Log()

--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ if (CLIENT) {
 	const Log = require('./build-es6/Log')
 	module.exports.log = new Log()
 	module.exports.middleware = {
-		requests: require('./build-es6/middleware/requests'),
-		koaRequests: require('./build-es6/middleware/koaRequests')
+		requests: require('./build-es6/middleware/requests')
+		// TODO: Implement koa request middleware
+		// koaRequests: require('./build-es6/middleware/koaRequests')
 	}
 	module.exports.nodeMetrics = require('./build-es6/collectors/node')
 	module.exports.sequelizeHooks = require('./build-es6/sequelize/hooks')

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
 	"description": "Sprucebot Logger",
 	"main": "index.js",
 	"files": [
+		"src",
 		"build",
 		"build-es6",
 		"client.js",
+		"flow-client.js",
 		"server.js"
 	],
 	"engines": {

--- a/server.js
+++ b/server.js
@@ -2,8 +2,9 @@ const Log = require('./build-es6/Log')
 
 module.exports.log = new Log()
 module.exports.middleware = {
-	requests: require('./build-es6/middleware/requests'),
-	koaRequests: require('./build-es6/middleware/koaRequests')
+	requests: require('./build-es6/middleware/requests')
+	// TODO: Implement koa request middleware
+	// koaRequests: require('./build-es6/middleware/koaRequests')
 }
 module.exports.nodeMetrics = require('./build-es6/collectors/node')
 module.exports.sequelizeHooks = require('./build-es6/sequelize/hooks')


### PR DESCRIPTION
Adding because its super handy for me to get the full type docs for logger and its methods. Leaving the other exports as they are, and just following the convention of the extant client.