### PR TITLE
[SDEV3-2318] Fix old code causing error on FE logs

### DIFF
--- a/src/Log/IsoLog.js
+++ b/src/Log/IsoLog.js
@@ -254,6 +254,12 @@ module.exports = class Log {
 					debug('Error stringifying thingToLog', e)
 				}
 			}
+
+			if (this.asJSON) {
+				consoleMethod.call(this, thingToLog)
+			} else {
+				consoleMethod.call(this, `${colorizedLevel}\n${thingToLog}`)
+			}
 		}
 	}
 

--- a/src/Log/IsoLog.js
+++ b/src/Log/IsoLog.js
@@ -255,22 +255,6 @@ module.exports = class Log {
 				}
 			}
 		}
-
-		if (CLIENT) {
-			if (thingType === 'string') {
-				thingToLog[0] = colorizedLevel[0] + thingToLog[0]
-				thingToLog[2] = thingToLog[1]
-				thingToLog[1] = colorizedLevel[1]
-				consoleMethod.call(this, thingToLog)
-			} else {
-				console.log.apply(this, colorizedLevel)
-				consoleMethod.call(this, thingToLog)
-			}
-		} else if (this.asJSON) {
-			consoleMethod.call(this, thingToLog)
-		} else {
-			consoleMethod.call(this, `${colorizedLevel}\n${thingToLog}`)
-		}
 	}
 
 	doLog(level: string, args: any, saveLog: boolean) {


### PR DESCRIPTION
On the client, the `thingToLog` logging is handled above this code block.  The second code block caused a FE error